### PR TITLE
Remove legacy package reference

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -29,7 +29,6 @@
 	"require-dev": {
 		"phpunit/phpunit" : "^7.0",
 		"mockery/mockery": "^1.0",
-		"mgatner/ci-module-tests": "^1.0",
 		"codeigniter4/codeigniter4": "dev-develop"
 	},
 	"autoload": {


### PR DESCRIPTION
The example **composer.json** has a reference to the old package that has since been moved and removed. This PR strips it out.