### PR TITLE
Reinstate SUPPORTPATH

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -27,9 +27,10 @@
 		"php" : ">=7.2"
 	},
 	"require-dev": {
-		"phpunit/phpunit" : "^7.0",
+		"codeigniter4/codeigniter4": "dev-develop",
+		"mikey179/vfsstream": "1.6.*",
 		"mockery/mockery": "^1.0",
-		"codeigniter4/codeigniter4": "dev-develop"
+		"phpunit/phpunit" : "^7.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/tests/_support/bootstrap.php
+++ b/src/tests/_support/bootstrap.php
@@ -19,12 +19,13 @@ define('ROOTPATH',      realpath(APPPATH . '../') . DIRECTORY_SEPARATOR);
 define('FCPATH',        realpath(ROOTPATH . 'public') . DIRECTORY_SEPARATOR);
 define('SYSTEMPATH',    realpath($paths->systemDirectory) . DIRECTORY_SEPARATOR);
 define('WRITEPATH',     realpath($paths->writableDirectory) . DIRECTORY_SEPARATOR);
+define('SUPPORTPATH',   realpath(ROOTPATH . 'tests/_support') . DIRECTORY_SEPARATOR);
 
 // Define necessary module test path constants
-define('SUPPORTPATH',   realpath(__DIR__) . DIRECTORY_SEPARATOR);
-define('TESTPATH',      realpath(SUPPORTPATH . '../') . DIRECTORY_SEPARATOR);
-define('MODULEPATH',    realpath(__DIR__ . '/../../') . DIRECTORY_SEPARATOR);
-define('COMPOSER_PATH', MODULEPATH . 'vendor/autoload.php');
+define('MODULESUPPORTPATH', realpath(__DIR__) . DIRECTORY_SEPARATOR);
+define('TESTPATH',          realpath(MODULESUPPORTPATH . '../') . DIRECTORY_SEPARATOR);
+define('MODULEPATH',        realpath(__DIR__ . '/../../') . DIRECTORY_SEPARATOR);
+define('COMPOSER_PATH',     MODULEPATH . 'vendor/autoload.php');
 
 // Set environment values that would otherwise stop the framework from functioning during tests.
 if (! isset($_SERVER['app.baseURL']))


### PR DESCRIPTION
The framework actually uses `SUPPORTPATH` to do some the behind-the-scenes mocking (like the test logger) so defining our own without supplying the mock drivers breaks functions that rely on them (like `log_message()`). This PR restores `SUPPORTPATH` to its framework reference and adds a new constant, `MODULESUPPORTPATH` for developers to use in its place.

Existing tests that reference `SUPPORTPATH` explicitly should be updated.