### PR TITLE
Fix paths, Specify migration group, Add Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ composer.lock
 Examples of **composer.json** and **.gitignore** are located in the [examples/](examples/)
 folder if you need a starting point.
 
+### Paths
+
+A number of framework and testing path are defined as constants during the
+[bootstrap process](src/tests/_support/bootstrap.php). These default to the assumed locations
+if you have a standard directory structure. If you move directories around you will need to
+review these paths and set them appropriately.
+
+* **APPPATH**: `$paths->appDirectory`
+* **ROOTPATH**: `APPPATH . '../'`
+* **FCPATH**: `ROOTPATH . 'public/'`
+* **WRITEPATH**: `$paths->writableDirectory`
+* **SYSTEMPATH**: `$paths->systemDirectory`
+* **CIPATH**: `SYSTEMPATH . '../`
+* **SUPPORTPATH**: `CIPATH . 'tests/_support/`
+* **PROJECTSUPPORTPATH**: *bootstrap.php directory*
+* **TESTPATH**: `PROJECTSUPPORTPATH . '../`
+
 ## Updating
 
 As this repo is updated with bugfixes and improvements you will want to update your

--- a/src/tests/_support/Database/Migrations/2019-09-02-092335_create_test_tables.php
+++ b/src/tests/_support/Database/Migrations/2019-09-02-092335_create_test_tables.php
@@ -4,6 +4,8 @@ use CodeIgniter\Database\Migration;
 
 class CreateTestTables extends Migration
 {
+	protected $DBGroup = 'tests';
+
 	public function up()
 	{
 		$fields = [

--- a/src/tests/_support/bootstrap.php
+++ b/src/tests/_support/bootstrap.php
@@ -17,9 +17,10 @@ $paths = new Config\Paths();
 define('APPPATH',       realpath($paths->appDirectory) . DIRECTORY_SEPARATOR);
 define('ROOTPATH',      realpath(APPPATH . '../') . DIRECTORY_SEPARATOR);
 define('FCPATH',        realpath(ROOTPATH . 'public') . DIRECTORY_SEPARATOR);
-define('SYSTEMPATH',    realpath($paths->systemDirectory) . DIRECTORY_SEPARATOR);
 define('WRITEPATH',     realpath($paths->writableDirectory) . DIRECTORY_SEPARATOR);
-define('SUPPORTPATH',   realpath(ROOTPATH . 'tests/_support') . DIRECTORY_SEPARATOR);
+define('SYSTEMPATH',    realpath($paths->systemDirectory) . DIRECTORY_SEPARATOR);
+define('CIPATH',        realpath(SYSTEMPATH . '../') . DIRECTORY_SEPARATOR);
+define('SUPPORTPATH',   realpath(CIPATH . 'tests/_support') . DIRECTORY_SEPARATOR);
 
 // Define necessary module test path constants
 define('MODULESUPPORTPATH', realpath(__DIR__) . DIRECTORY_SEPARATOR);


### PR DESCRIPTION
These are the equivalent changes to ProjectTests to ensure that migrations are only run during testing, to update `SUPPORTPATH` to the correct directory, and to add docs on when paths need to be updated.