### PR TITLE
Bootstrap Common.php

### DIFF
--- a/src/tests/_support/bootstrap.php
+++ b/src/tests/_support/bootstrap.php
@@ -34,6 +34,21 @@ if (! isset($_SERVER['app.baseURL']))
 	$_SERVER['app.baseURL'] = 'http://example.com';
 }
 
+// Let's see if an app/Common.php file exists
+if (file_exists(APPPATH . 'Common.php'))
+{
+	require_once APPPATH . 'Common.php';
+}
+
+// Require system/Common.php
+require_once SYSTEMPATH . 'Common.php';
+
+// Set environment values that would otherwise stop the framework from functioning during tests.
+if (! isset($_SERVER['app.baseURL']))
+{
+	$_SERVER['app.baseURL'] = 'http://example.com';
+}
+
 // Load necessary modules
 require_once APPPATH . 'Config/Autoload.php';
 require_once APPPATH . 'Config/Constants.php';

--- a/src/tests/_support/bootstrap.php
+++ b/src/tests/_support/bootstrap.php
@@ -28,12 +28,6 @@ define('TESTPATH',          realpath(MODULESUPPORTPATH . '../') . DIRECTORY_SEPA
 define('MODULEPATH',        realpath(__DIR__ . '/../../') . DIRECTORY_SEPARATOR);
 define('COMPOSER_PATH',     MODULEPATH . 'vendor/autoload.php');
 
-// Set environment values that would otherwise stop the framework from functioning during tests.
-if (! isset($_SERVER['app.baseURL']))
-{
-	$_SERVER['app.baseURL'] = 'http://example.com';
-}
-
 // Let's see if an app/Common.php file exists
 if (file_exists(APPPATH . 'Common.php'))
 {


### PR DESCRIPTION
The current bootstrap process does not load **Common.php** which can cause testing to fail when relying on functions defined there. This PR adds that early on to make sure all functions are defined before launch, mimicking the framework's priority of App > System.