### PR TITLE
Fix fox MockSession loading

### DIFF
--- a/src/tests/_support/SessionTestCase.php
+++ b/src/tests/_support/SessionTestCase.php
@@ -1,7 +1,7 @@
 <?php namespace ModuleTests\Support;
 
 use CodeIgniter\Session\Handlers\ArrayHandler;
-use Tests\Support\Session\MockSession;
+use CodeIgniter\Test\Mock\MockSession;
 
 class SessionTestCase extends \CodeIgniter\Test\CIUnitTestCase
 {
@@ -24,7 +24,7 @@ class SessionTestCase extends \CodeIgniter\Test\CIUnitTestCase
      */
     protected function mockSession()
     {
-        require_once ROOTPATH . 'tests/_support/Session/MockSession.php';
+        require_once SYSTEMPATH . 'Test/Mock/MockSession.php';
         $config = config('App');
         $this->session = new MockSession(new ArrayHandler($config, '0.0.0.0'), $config);
         \Config\Services::injectMock('session', $this->session);


### PR DESCRIPTION
Fix for loading `MockSession`.
Also quick question. Why do we need `require_once` part?